### PR TITLE
change the deprecated mimetype argument of HttpResponse __init__ method ...

### DIFF
--- a/djangorpc/router.py
+++ b/djangorpc/router.py
@@ -67,7 +67,7 @@ class RpcRouter(object):
         if not isinstance(requests, list):
             requests = [requests]
 
-        response = HttpResponse('', mimetype="application/json")
+        response = HttpResponse('', content_type="application/json")
 
         output = []
 


### PR DESCRIPTION
change the deprecated "mimetype" argument of HttpResponse **init** method into "content_type" to be compatible with django>=1.7
